### PR TITLE
Add settings link to plugin description

### DIFF
--- a/beltway-wp-pco.php
+++ b/beltway-wp-pco.php
@@ -17,3 +17,13 @@ require_once(dirname(__FILE__).'/admin.php');
 
 // scripts
 require_once('scripts/recentsinging.php');
+
+function beltway_plugin_action_links( $links, $file ) {
+	$plugin_file = basename(__FILE__);
+	if (basename($file) == $plugin_file) {
+		$links[] = '<a href="' . admin_url( 'options-general.php?page=pco_connect' ) . '">'.__( 'Settings' ).'</a>';
+	}
+	return $links;
+}
+
+add_filter( 'plugin_action_links', 'beltway_plugin_action_links', 10, 2 );


### PR DESCRIPTION
Small change to add a settings link next to the Deactivate and Edit links on the wordpress plugins page
